### PR TITLE
feat: SSR getServerSideProps 에서 Authorization header에 쿠키 삽입, 로그인 쿠키에 isProfile 추가

### DIFF
--- a/components/commons/filter/FilterAmount.tsx
+++ b/components/commons/filter/FilterAmount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './FilterAmount.module.scss';
-import MoneyInput from '../inputs/moneyInput/MoneyInput';
+import FilterMoneyInput from './FilterMoneyInput';
 
 /**
  * filter 금액에 대한 컴포넌트 입니다.
@@ -15,7 +15,7 @@ interface MoneyProps {
 export default function FilterAmount({ money, setMoney }: MoneyProps) {
   return (
     <div className={styles.filterAmount}>
-      <MoneyInput labelName="금액" value={money} setValue={setMoney} />
+      <FilterMoneyInput labelName="금액" value={money} setValue={setMoney} />
     </div>
   );
 }

--- a/components/commons/filter/FilterMoneyInput.module.scss
+++ b/components/commons/filter/FilterMoneyInput.module.scss
@@ -1,0 +1,39 @@
+.container {
+  @include body1-regular(--black);
+  width: 100%;
+  position: relative;
+
+  .input {
+    @include body1-regular(--black);
+    width: 100%;
+    height: 58px;
+    padding: 16px 60px 16px 20px;
+    margin-top: 8px;
+    border-radius: 6px;
+    border: 1px solid var(--gray30);
+    background: var(--white);
+    outline: none;
+
+    &::placeholder {
+      color: var(--gray40);
+    }
+
+    // input type: number의 화살표 제거 Chrome, Safari, Edge, Opera
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+  }
+
+  // input type: number의 화살표 제거 Firefox
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
+
+  .won {
+    position: absolute;
+    bottom: 16px;
+    right: 20px;
+  }
+}

--- a/components/commons/filter/FilterMoneyInput.tsx
+++ b/components/commons/filter/FilterMoneyInput.tsx
@@ -1,0 +1,65 @@
+import styles from '@/components/commons/filter/FilterMoneyInput.module.scss';
+import React from 'react';
+
+/**
+ * 숫자만 입력할 수 있는 input 입니다.
+ * 금액 관련한 정보가 필요할 때 사용 가능하며, 기본 단위는 원 입니다.
+ * 추가로 최저 시급보다 적게 입력 시 자동으로 최저 시급으로 변경합니다.
+ * @param {labelName} props label로 사용할 input의 이름을 적어주면 됩니다.
+ * @param {value} props 해당 인풋에서 사용할 State
+ * @param {setValue} props 해당 인풋에서 사용할 state를 변경할 seter 함수
+ */
+
+interface FilterMoneyInputProps {
+  labelName: string;
+  value: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const MINIMUM_WAGE = 9860;
+
+export default function FilterMoneyInput({
+  labelName,
+  value,
+  setValue,
+}: FilterMoneyInputProps) {
+  const formatWage = (InputValue: string): string => {
+    // 숫자를 제외한 모든 문자를 공백으로 변환, 숫자 입력만 허용하기 위한 정규식
+    const numericValue = InputValue.replace(/\D/g, '');
+    // 숫자 3자리 마다 콤마 삽입
+    const formattedValue = numericValue.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+    return formattedValue;
+  };
+
+  const removeComma = (formattedValue: string): string => {
+    // 숫자 3자리 마다 들어간 콤마 제거
+    return formattedValue.replace(/\D/g, '');
+  };
+
+  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    setValue(formatWage(event.currentTarget.value));
+  };
+
+  const handleFocusOut = (event: React.FormEvent<HTMLInputElement>) => {
+    if (Number(removeComma(event.currentTarget.value)) < MINIMUM_WAGE) {
+      setValue(formatWage(String(MINIMUM_WAGE)));
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <label htmlFor={labelName}>{labelName}</label>
+      <input
+        id={labelName}
+        className={styles.input}
+        value={value}
+        type="text"
+        placeholder="입력"
+        onChange={handleChange}
+        onBlur={handleFocusOut}
+      />
+      <div className={styles.won}>원</div>
+    </div>
+  );
+}

--- a/hooks/useSignIn.tsx
+++ b/hooks/useSignIn.tsx
@@ -26,6 +26,9 @@ export default function useSignIn() {
       document.cookie = `accessToken=${response.data.item.token}; secure`;
       document.cookie = `userId=${response.data.item.user.item.id}; secure`;
       document.cookie = `type=${response.data.item.user.item.type}; secure`;
+      if (response.data.item.user.item.name) {
+        document.cookie = 'isProfile=true; secure';
+      }
       router.push('/');
     } catch (error) {
       if (axios.isAxiosError(error)) {

--- a/libs/index.ts
+++ b/libs/index.ts
@@ -26,6 +26,15 @@ export const nextInstance = axios.create({
   },
 });
 
+// getServerSideProps 전용 인스턴스
+export const ssrInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  timeout: 1000 * 5,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
 // interceptors
 authInstance.interceptors.request.use(
   async config => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^18",
         "react-datepicker": "^6.9.0",
         "react-dom": "^18",
-        "react-hook-form": "^7.51.3".
+        "react-hook-form": "^7.51.3",
         "sass": "^1.75.0",
         "swiper": "^11.1.1"
       },

--- a/utils/findCookieValue.ts
+++ b/utils/findCookieValue.ts
@@ -1,0 +1,9 @@
+export default function findCookieValue(cookies: string, key: string): string {
+  const cookieList: string[] = cookies.split('; ');
+  const cookieMap: { [key: string]: string } = {};
+  cookieList.forEach(cookie => {
+    const [cookieKey, cookieValue] = cookie.split('=');
+    cookieMap[cookieKey] = cookieValue;
+  });
+  return cookieMap[key] || '';
+}

--- a/utils/findCookieValue.ts
+++ b/utils/findCookieValue.ts
@@ -1,3 +1,9 @@
+/**
+ * 쿠키는 통으로 하나인 문자열 이라 키 값을 기준으로 잘라서 사용하는 쿠키 커터
+ * @param cookies
+ * @param key
+ */
+
 export default function findCookieValue(cookies: string, key: string): string {
   const cookieList: string[] = cookies.split('; ');
   const cookieMap: { [key: string]: string } = {};

--- a/utils/setServerSideCookie.ts
+++ b/utils/setServerSideCookie.ts
@@ -1,0 +1,17 @@
+import { ssrInstance } from '@/libs';
+import { GetServerSidePropsContext } from 'next';
+import findCookieValue from './findCookieValue';
+
+export function setServerSideCookie(context: GetServerSidePropsContext) {
+  const cookies = context.req.headers.cookie;
+
+  if (!cookies) {
+    return;
+  }
+
+  const accessToken = findCookieValue(cookies, 'accessToken');
+
+  if (accessToken !== '') {
+    ssrInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+  }
+}

--- a/utils/setServerSideCookie.ts
+++ b/utils/setServerSideCookie.ts
@@ -2,6 +2,11 @@ import { ssrInstance } from '@/libs';
 import { GetServerSidePropsContext } from 'next';
 import findCookieValue from './findCookieValue';
 
+/**
+ * getServerSideProps 사용 시 instance의 Authorization header에 쿠키값 넣어주는 함수
+ * @param context getServerSideProps의 context 넣기
+ */
+
 export function setServerSideCookie(context: GetServerSidePropsContext) {
   const cookies = context.req.headers.cookie;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61
## 📝작업 내용

> SSR getServerSideProps 에서 Authorization header에 쿠키 삽입
> 로그인 쿠키에 isProfile 추가
> 동현님 필터에서 사용하시는 Money input이 오류가 나서 수정했습니다. 하나의 공통 인풋을 한쪽에서는 제어 컴포넌트로 한쪽에서는 리액트 훅 폼으로 비제어 컴포넌트로 사용해 둘이 사용하는 프롭과 제어 방식이 달라 충돌이 나는 거 같습니다. 최대한 공통으로 처리하려고 고민해봤지만, 두 곳이 사용 방식이 전혀 달라 같이 사용할 수 없다고 판단하였고 동현님이 필터에서 쓰시던 인풋은 이전에 사용하던 버전으로 따로 분리했습니다.

### 스크린샷 (선택)
1. 쿠키는 그냥 쓰면 모든 정보가 묶인 통으로된 쿠키 입니다!! 아래 예시처럼 예외 처리하고 함수로 잘라서 써주면 됩니다.
<img width="970" alt="스크린샷 2024-04-24 22 49 24" src="https://github.com/TheJulge/Frontend/assets/155162841/a99ab18c-1ab2-47f0-ac6e-b733b731acb3">

2. getServerSideProps에서 인증이 필요한 요청은 아래 사진처럼 ssrInstance 쓰시면 됩니다.
<img width="923" alt="스크린샷 2024-04-24 22 50 48" src="https://github.com/TheJulge/Frontend/assets/155162841/152d464a-d6f9-4a9f-9485-8b837b7db2d2">

프로필 등록 했을 때
<img width="240" alt="스크린샷 2024-04-25 02 27 58" src="https://github.com/TheJulge/Frontend/assets/155162841/61d79401-f9ef-4e92-b607-f8b63ab653f6">

프로필 등록 안 했을 때
<img width="242" alt="스크린샷 2024-04-25 02 28 22" src="https://github.com/TheJulge/Frontend/assets/155162841/ea889c4b-e8b6-4fa0-a211-940e4d8d393b">


## 💬리뷰 요구사항(선택)

> 이것만 기억하자!!
1. export async function getServerSideProps(context: GetServerSidePropsContext){} 이렇게 사용하자
2. const cookies = context.req.headers.cookie; 요청에서 쿠키를 꺼내자!
3. 필요한 쿠키만 const accessToken = findCookieValue(cookies, 'accessToken'); 이렇게 꺼내자! 단, 쿠키가 없을 수 있으니 예외처리 필수! 쿠키가 없으면 로그인 상태가 아니니 로그인 창으로 보내자!
4. SSR에서 요청이 필요하면 setServerSideCookie(context); 호출 그러면 자동으로 인증토근이 담긴다!
5. 반드시 getServerSideProps 내에서 통신은 ssrInstance 사용하자!

getServerSideProps 이외에 인증이 필요한 곳은 평소대로 authInstance 쓰자 그럼 이만!